### PR TITLE
fix off-by-one issue with etopo data

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ oceanmesh: Automatic coastal ocean mesh generation
 
 
 
-Coastal ocean mesh generation from ESRI Shapefiles and digitial elevation models.
+Coastal ocean mesh generation from ESRI Shapefiles and digital elevation models.
 
 
 Functionality
@@ -29,10 +29,14 @@ Otherwise please reach out to either Dr. William Pringle (wpringle@nd.edu) or Dr
 Installation
 ============
 
-For installation, oceanmesh needs [CGAL](https://www.cgal.org/) and
+For installation, oceanmesh needs [cmake](https://cmake.org/), [CGAL](https://www.cgal.org/) and
 [pybind11](https://github.com/pybind/pybind11):
 
-    sudo apt install libcgal-dev python3-pybind11
+    sudo apt install cmake libcgal-dev python3-pybind11
+
+CGAL and pybind can also be installed with [`conda`](https://www.anaconda.com/products/individual):
+
+    conda install -c conda-forge cgal pybind11 
 
 After that, clone the repo and oceanmesh can be updated/installed using pip.
 

--- a/oceanmesh/edgefx.py
+++ b/oceanmesh/edgefx.py
@@ -6,7 +6,9 @@ from .grid import Grid
 __all__ = ["distance_sizing_function", "wavelength_sizing_function"]
 
 
-def distance_sizing_function(shoreline, rate=0.15, max_edge_length=None, verbose=1):
+def distance_sizing_function(
+    shoreline, rate=0.15, max_edge_length=None, verbose=1, coarsen=1
+):
     """Mesh sizes that vary linearly at `rate` from coordinates in `obj`:Shoreline
 
     Parameters
@@ -15,6 +17,12 @@ def distance_sizing_function(shoreline, rate=0.15, max_edge_length=None, verbose
         Data processed from :class:`Shoreline`.
     rate: float, optional
         The rate of expansion in decimal percent from the shoreline.
+    max_edge_length: float, optional
+        The maximum allowable edge length
+    verbose: boolean, optional
+        Whether to write messages to the screen
+    coarsen: integer, optional
+        Downsample the grid by a constant factor in x and y axes
 
     Returns
     -------
@@ -24,7 +32,7 @@ def distance_sizing_function(shoreline, rate=0.15, max_edge_length=None, verbose
     """
     if verbose > 0:
         print("Building a distance sizing function...")
-    grid = Grid(bbox=shoreline.bbox, dx=shoreline.h0, hmin=shoreline.h0)
+    grid = Grid(bbox=shoreline.bbox, dx=shoreline.h0 * coarsen, hmin=shoreline.h0)
     # create phi (-1 where shoreline point intersects grid points 1 elsewhere)
     phi = numpy.ones(shape=(grid.nx, grid.ny))
     lon, lat = grid.create_grid()
@@ -43,7 +51,11 @@ def distance_sizing_function(shoreline, rate=0.15, max_edge_length=None, verbose
 
 
 def wavelength_sizing_function(
-    dem, wl=10, min_edgelength=None, max_edge_length=None, verbose=1
+    dem,
+    wl=10,
+    min_edgelength=None,
+    max_edge_length=None,
+    verbose=1,
 ):
     """Mesh sizes that vary proportional to an estimate of the wavelength
        of the M2 tidal constituent
@@ -59,6 +71,9 @@ def wavelength_sizing_function(
         of the edgelength function is used.
     max_edge_length: float, optional
         The maximum edge length in meters in the domain.
+    verbose: boolean, optional
+        Whether to write messages to the screen
+
 
     Returns
     -------

--- a/oceanmesh/geodata.py
+++ b/oceanmesh/geodata.py
@@ -332,7 +332,9 @@ class Shoreline(Geodata):
         value /= 111e3  # convert to wgs84 degrees
         self.__h0 = value
 
-    def plot(self, ax=None, xlabel=None, ylabel=None, title=None):
+    def plot(
+        self, ax=None, xlabel=None, ylabel=None, title=None, file_name=None, show=True
+    ):
         """Visualize the content in the shp field of Shoreline"""
         import matplotlib.pyplot as plt
 
@@ -379,7 +381,10 @@ class Shoreline(Geodata):
 
         ax.set_aspect("equal", adjustable="box")
 
-        plt.show()
+        if show:
+            plt.show()
+        if file_name is not None:
+            plt.savefig(file_name)
         return ax
 
 
@@ -407,10 +412,11 @@ def _extract_bounds(lons, lats, bbox):
         )
     # latitude lower and upper index
     latli = numpy.argmin(numpy.abs(lats - bbox[2]))
-    latui = numpy.argmin(numpy.abs(lats - bbox[3]))
+    latui = numpy.argmin(numpy.abs(lats - bbox[3])) + 1
     # longitude lower and upper index
     lonli = numpy.argmin(numpy.abs(lons - bbox[0]))
-    lonui = numpy.argmin(numpy.abs(lons - bbox[1]))
+    lonui = numpy.argmin(numpy.abs(lons - bbox[1])) + 1
+
     return latli, latui, lonli, lonui
 
 
@@ -504,6 +510,6 @@ class DEM(Grid):
             bbox=bbox,
             dx=dx,
             dy=dy,
-            values=topobathy.T,
         )
+        self.values = topobathy[: self.ny, : self.nx].T
         super().build_interpolant()

--- a/oceanmesh/grid.py
+++ b/oceanmesh/grid.py
@@ -63,8 +63,8 @@ class Grid:
         self.dx = dx
         self.dy = dy
         self.hmin = hmin
-        self.nx = int(floor((self.bbox[1] - self.bbox[0]) / self.dx))
-        self.ny = int(floor((self.bbox[3] - self.bbox[2]) / self.dy))
+        self.nx = int((self.bbox[1] - self.bbox[0]) // self.dx) + 1
+        self.ny = int((self.bbox[3] - self.bbox[2]) // self.dy) + 1
         self.values = values
         self.eval = None
         self.fill = fill

--- a/oceanmesh/grid.py
+++ b/oceanmesh/grid.py
@@ -54,8 +54,6 @@ class Grid:
     """
 
     def __init__(self, bbox, dx, dy=None, hmin=None, values=None, fill=None):
-        floor = numpy.floor
-
         if dy is None:
             dy = dx
         self.bbox = bbox
@@ -115,14 +113,10 @@ class Grid:
         if numpy.isscalar(data):
             data = numpy.tile(data, (self.nx, self.ny))
         elif data is None:
-            pass
-        elif data.shape != (self.nx, self.ny):
-            raise ValueError(
-                f"Shape of values {data.shape} does not match grid size {self.nx, self.ny}"
-            )
-        self.__values = data
+            return
+        self.__values = data[: self.nx, : self.ny]
 
-    def create_vectors(self, coarsen=1):
+    def create_vectors(self):
         """Build coordinate vectors
 
         Parameters
@@ -137,11 +131,11 @@ class Grid:
             1D array contain data with `float` type of y-coordinates.
 
         """
-        x = self.x0y0[0] + numpy.arange(0, self.nx) * self.dx * coarsen
-        y = self.x0y0[1] + numpy.arange(0, self.ny) * self.dy * coarsen
+        x = self.x0y0[0] + numpy.arange(0, self.nx) * self.dx
+        y = self.x0y0[1] + numpy.arange(0, self.ny) * self.dy
         return x, y
 
-    def create_grid(self, coarsen=1):
+    def create_grid(self):
         """Build a structured grid
 
         Parameters
@@ -156,7 +150,7 @@ class Grid:
             2D array contain data with `float` type.
 
         """
-        x, y = self.create_vectors(coarsen)
+        x, y = self.create_vectors()
         return numpy.meshgrid(x, y, sparse=False, indexing="ij")
 
     def find_indices(self, points, lon, lat, tree=None):
@@ -243,6 +237,7 @@ class Grid:
     def plot(
         self,
         hold=False,
+        show=True,
         vmin=None,
         vmax=None,
         coarsen=1,
@@ -250,6 +245,7 @@ class Grid:
         ylabel=None,
         title=None,
         cbarlabel=None,
+        file_name=None,
     ):
         """Visualize the values in :obj:`Grid`
 
@@ -265,23 +261,31 @@ class Grid:
 
         """
 
-        x, y = self.create_grid(coarsen)
+        x, y = self.create_grid()
 
         fig, ax = plt.subplots()
-        c = ax.pcolormesh(x, y, self.values, vmin=vmin, vmax=vmax, shading="auto")
-        cbar = plt.colorbar(c)
-        if cbar is not None:
-            cbar.set_label(cbarlabel)
         ax.axis("equal")
+        c = ax.pcolormesh(
+            x[:-1:coarsen, :-1:coarsen],
+            y[:-1:coarsen, :-1:coarsen],
+            self.values[:-1:coarsen, :-1:coarsen],
+            vmin=vmin,
+            vmax=vmax,
+            shading="auto",
+        )
+        cbar = plt.colorbar(c)
+        if cbarlabel is not None:
+            cbar.set_label(cbarlabel)
         if xlabel is not None:
             ax.set_xlabel(xlabel)
         if ylabel is not None:
             ax.set_ylabel(ylabel)
         if title is not None:
             ax.set_title(title)
-        if hold is False:
-            fig.colorbar(c, ax=ax)
+        if hold is False and show:
             plt.show()
+        if file_name is not None:
+            plt.savefig(file_name)
         return ax
 
     def build_interpolant(self):
@@ -295,6 +299,7 @@ class Grid:
 
         """
         lon1, lat1 = self.create_vectors()
+
         fp = RegularGridInterpolator(
             (lon1, lat1),
             self.values,

--- a/oceanmesh/mesh_generator.py
+++ b/oceanmesh/mesh_generator.py
@@ -346,5 +346,5 @@ def _unpack_pfix(dim, opts):
 
 
 def _get_topology(dt):
-    """ Get points and entities from :clas:`CGAL:DelaunayTriangulation2/3` object"""
+    """Get points and entities from :clas:`CGAL:DelaunayTriangulation2/3` object"""
     return dt.get_finite_vertices(), dt.get_finite_cells()


### PR DESCRIPTION
This PR fixes the issue #22 with using[ Etopo 1](https://www.ngdc.noaa.gov/mgg/global/) bathymetric data.

This fix will cause the unit test reading the `.tiff` file to fail. I am not exactly sure what the difference between the data types is.

Also fixed minor a few typos and add a note about installation with `conda`. 

This code will work now:

```python
fname = "gshhg-shp-2.3.7/GSHHS_shp/i/GSHHS_i_L1.shp"

bbox, min_edge_length = (-75.000, -70.001, 40.0001, 41.9000), 1e3

shore = Shoreline(fname, bbox, min_edge_length)

# This file is just Etopo data with with longitudes in the -180 to 180 referential. Original etopo data uses 0-360 referential.
fname = "etopo1fix.nc"  

dem = DEM(fname, bbox)

edge_length = distance_sizing_function(shore, max_edge_length=5e3)

domain = signed_distance_function(shore)

points, cells = generate_mesh(domain, edge_length)

# remove degenerate mesh faces and other common problems in the mesh
points, cells = make_mesh_boundaries_traversable(points, cells)

points, cells = delete_faces_connected_to_one_face(points, cells)

# plot
fig, ax = plt.subplots()
ax.set_aspect('equal')
triang = tri.Triangulation(points[:, 0], points[:, 1], cells)
ax.triplot(triang, '-', lw=1)
plt.show()
```