### PR TITLE
support irregular domains

### DIFF
--- a/oceanmesh/signed_distance_function.py
+++ b/oceanmesh/signed_distance_function.py
@@ -18,7 +18,7 @@ class Domain:
         return self.domain(x)
 
 
-def signed_distance_function(shoreline, verbose=1):
+def signed_distance_function(shoreline, verbose=1, flip=0):
     """Takes a `shoreline` object containing segments representing islands and mainland boundaries
     and calculates a signed distance function with it (assuming the polygons are all closed).
     This function is queried every meshing iteration.
@@ -40,7 +40,7 @@ def signed_distance_function(shoreline, verbose=1):
     tree = scipy.spatial.cKDTree(poly[~numpy.isnan(poly[:, 0]), :], balanced_tree=False)
     e = edges.get_poly_edges(poly)
 
-    boubox = _create_boubox(shoreline.bbox)
+    boubox = shoreline.boubox
     e_box = edges.get_poly_edges(boubox)
 
     def func(x):
@@ -55,22 +55,9 @@ def signed_distance_function(shoreline, verbose=1):
         # d is signed negative if inside the
         # intersection of two areas and vice versa.
         cond = numpy.logical_and(in_shoreline, in_boubox)
+        if flip:
+            cond = ~cond
         dist = (-1) ** (cond) * d
         return dist
 
     return Domain(shoreline.bbox, func)
-
-
-def _create_boubox(bbox):
-    """Create a bounding box from domain extents `bbox`."""
-    xmin, xmax, ymin, ymax = bbox
-    return numpy.array(
-        [
-            [xmin, ymin],
-            [xmax, ymin],
-            [xmax, ymax],
-            [xmin, ymax],
-            [xmin, ymin],
-            [nan, nan],
-        ]
-    )

--- a/tests/test_irregular_domain.py
+++ b/tests/test_irregular_domain.py
@@ -2,32 +2,33 @@ import matplotlib.tri as tri
 import matplotlib.pyplot as plt
 import numpy as np
 import oceanmesh as om
- 
+
+
 def test_irregular_domain():
     fname = "gshhg-shp-2.3.7/GSHHS_shp/f/GSHHS_f_L1.shp"
 
-    # New York Lower Bay and Jamaica Bay 
+    # New York Lower Bay and Jamaica Bay
     bbox = np.array(
-     [
-         [-74.1588, 40.5431],
-         [-74.1215, 40.4847],
-         [-74.0261, 40.4660],
-         [-73.9369, 40.5034],
-         [-73.8166, 40.5104],
-         [-73.7524, 40.5711],
-         [-73.7627, 40.6669],
-         [-73.8436, 40.6809],
-         [-73.9473, 40.6552],
-         [-74.0883, 40.6155],
-         [-74.1588, 40.5431],
-     ]
+        [
+            [-74.1588, 40.5431],
+            [-74.1215, 40.4847],
+            [-74.0261, 40.4660],
+            [-73.9369, 40.5034],
+            [-73.8166, 40.5104],
+            [-73.7524, 40.5711],
+            [-73.7627, 40.6669],
+            [-73.8436, 40.6809],
+            [-73.9473, 40.6552],
+            [-74.0883, 40.6155],
+            [-74.1588, 40.5431],
+        ]
     )
- 
+
     min_edge_length = 100
 
     shore = om.Shoreline(fname, bbox, min_edge_length)
     shore.plot(file_name="test_irregular_domain.png", show=False)
-    
+
     edge_length = om.distance_sizing_function(shore, max_edge_length=1e3)
 
     domain = om.signed_distance_function(shore)
@@ -38,7 +39,7 @@ def test_irregular_domain():
 
     points, cells = om.delete_faces_connected_to_one_face(points, cells)
 
-    # plot 
+    # plot
     fig, ax = plt.subplots()
     ax.set_aspect("equal")
     triang = tri.Triangulation(points[:, 0], points[:, 1], cells)

--- a/tests/test_irregular_domain.py
+++ b/tests/test_irregular_domain.py
@@ -1,0 +1,47 @@
+import matplotlib.tri as tri
+import matplotlib.pyplot as plt
+import numpy as np
+import oceanmesh as om
+ 
+def test_irregular_domain():
+    fname = "gshhg-shp-2.3.7/GSHHS_shp/f/GSHHS_f_L1.shp"
+
+    # New York Lower Bay and Jamaica Bay 
+    bbox = np.array(
+     [
+         [-74.1588, 40.5431],
+         [-74.1215, 40.4847],
+         [-74.0261, 40.4660],
+         [-73.9369, 40.5034],
+         [-73.8166, 40.5104],
+         [-73.7524, 40.5711],
+         [-73.7627, 40.6669],
+         [-73.8436, 40.6809],
+         [-73.9473, 40.6552],
+         [-74.0883, 40.6155],
+         [-74.1588, 40.5431],
+     ]
+    )
+ 
+    min_edge_length = 100
+
+    shore = om.Shoreline(fname, bbox, min_edge_length)
+    shore.plot(file_name="test_irregular_domain.png", show=False)
+    
+    edge_length = om.distance_sizing_function(shore, max_edge_length=1e3)
+
+    domain = om.signed_distance_function(shore)
+
+    points, cells = om.generate_mesh(domain, edge_length, verbose=2, max_iter=50)
+
+    points, cells = om.make_mesh_boundaries_traversable(points, cells)
+
+    points, cells = om.delete_faces_connected_to_one_face(points, cells)
+
+    # plot 
+    fig, ax = plt.subplots()
+    ax.set_aspect("equal")
+    triang = tri.Triangulation(points[:, 0], points[:, 1], cells)
+    ax.triplot(triang, "-", lw=1)
+    plt.savefig("test_irregular_domain_mesh.png")
+    plt.show()


### PR DESCRIPTION
* Per #23 `bbox` can now be an irregularly-shaped polygon (i.e, non rectangular) with this PR

```
 import matplotlib.tri as tri
 import matplotlib.pyplot as plt
 import numpy as np
 import oceanmesh as om
 
 
 bbox = np.array(
     [
         [-74.1588, 40.5431],
         [-74.1215, 40.4847],
         [-74.0261, 40.4660],
         [-73.9369, 40.5034],
         [-73.8166, 40.5104],
         [-73.7524, 40.5711],
         [-73.7627, 40.6669],
         [-73.8436, 40.6809],
         [-73.9473, 40.6552],
         [-74.0883, 40.6155],
         [-74.1588, 40.5431],
     ]
 )
 
 fname = "GSHHS_shp/f/GSHHS_f_L1.shp"
 min_edge_length = 25
 shore = om.Shoreline(fname, bbox, min_edge_length)
 shore.plot(file_name="testing_irregular.png", show=False)
 edge_length = om.distance_sizing_function(shore, max_edge_length=1e3)
 domain = om.signed_distance_function(shore)
 points, cells = om.generate_mesh(domain, edge_length, verbose=2, max_iter=50)
 points, cells = om.make_mesh_boundaries_traversable(points, cells)
 points, cells = om.delete_faces_connected_to_one_face(points, cells)
 
 fig, ax = plt.subplots()
 ax.set_aspect("equal")
 triang = tri.Triangulation(points[:, 0], points[:, 1], cells)
 ax.triplot(triang, "-", lw=1)
 plt.savefig("irregular_domain.png")
 plt.show()
```

![nonsquare2](https://user-images.githubusercontent.com/18619644/127418917-fad54249-52bf-492a-a0bf-587fa18df0ca.png)
![nonsquare](https://user-images.githubusercontent.com/18619644/127418921-7a4fb3ee-6e5b-4a58-bfc3-ed7ea949d6fa.png)
