### PR TITLE
adding gradient limiting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ build/
 *.hdf5
 *.msh
 *.so
+*.png
+tests/*.txt
+*.zip
+tests/gshhg-shp-2.3.7/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,4 +33,5 @@ message(STATUS "Found pybind11 v${pybind11_VERSION}: ${pybind11_INCLUDE_DIRS}")
 
 #add_subdirectory(pybind11)
 pybind11_add_module(delaunay_class ${SOURCES} "${SRC}/delaunay_class.cpp")
+pybind11_add_module(HamiltonJacobi ${SOURCES} "${SRC}/HamiltonJacobi.cpp")
 pybind11_add_module(fast_geometry ${SOURCES} "${SRC}/fast_geometry.cpp")

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Otherwise please reach out to either Dr. Keith Roberts (keithrbt0@gmail.com) or 
 Installation
 ============
 
-For installation, oceanmesh needs [cmake](https://cmake.org/), [CGAL](https://www.cgal.org/) and
+For installation, oceanmesh needs [cmake](https://cmake.org/), [gmp](https://gmplib.org/), [mpfr](https://www.mpfr.org/), [CGAL](https://www.cgal.org/) and
 [pybind11](https://github.com/pybind/pybind11):
 
-    sudo apt install cmake libcgal-dev python3-pybind11
+    sudo apt install cmake libmpfr-dev libgmp3-dev libcgal-dev python3-pybind11
 
 CGAL and pybind can also be installed with [`conda`](https://www.anaconda.com/products/individual):
 

--- a/oceanmesh/__init__.py
+++ b/oceanmesh/__init__.py
@@ -1,10 +1,9 @@
-from oceanmesh.clean import (
-    delete_exterior_faces,
-    delete_faces_connected_to_one_face,
-    delete_interior_faces,
-    make_mesh_boundaries_traversable,
-)
-from oceanmesh.edgefx import distance_sizing_function, wavelength_sizing_function
+from oceanmesh.clean import (delete_exterior_faces,
+                             delete_faces_connected_to_one_face,
+                             delete_interior_faces,
+                             make_mesh_boundaries_traversable)
+from oceanmesh.edgefx import (distance_sizing_function, enforce_mesh_gradation,
+                              wavelength_sizing_function)
 from oceanmesh.edges import draw_edges, get_poly_edges
 from oceanmesh.geodata import DEM, Geodata, Shoreline
 from oceanmesh.grid import Grid, compute_minimum
@@ -28,6 +27,7 @@ __all__ = [
     "Domain",
     "Shoreline",
     "distance_sizing_function",
+    "enforce_mesh_gradation",
     "wavelength_sizing_function",
     "signed_distance_function",
     "get_poly_edges",

--- a/oceanmesh/__init__.py
+++ b/oceanmesh/__init__.py
@@ -1,9 +1,14 @@
-from oceanmesh.clean import (delete_exterior_faces,
-                             delete_faces_connected_to_one_face,
-                             delete_interior_faces,
-                             make_mesh_boundaries_traversable)
-from oceanmesh.edgefx import (distance_sizing_function, enforce_mesh_gradation,
-                              wavelength_sizing_function)
+from oceanmesh.clean import (
+    delete_exterior_faces,
+    delete_faces_connected_to_one_face,
+    delete_interior_faces,
+    make_mesh_boundaries_traversable,
+)
+from oceanmesh.edgefx import (
+    distance_sizing_function,
+    enforce_mesh_gradation,
+    wavelength_sizing_function,
+)
 from oceanmesh.edges import draw_edges, get_poly_edges
 from oceanmesh.geodata import DEM, Geodata, Shoreline
 from oceanmesh.grid import Grid, compute_minimum

--- a/oceanmesh/cpp/HamiltonJacobi.cpp
+++ b/oceanmesh/cpp/HamiltonJacobi.cpp
@@ -70,7 +70,7 @@ std::vector<double> c_gradient_limit(const std::vector<int> &dims, const double 
 
   double ftol = *(std::min_element(ffun.begin(), ffun.end())) * std::sqrt(EPS);
 
-  std::array<int, 7> npos;
+  std::array<int, 9> npos;
   npos.fill(0);
 
   // allocate output
@@ -101,32 +101,35 @@ std::vector<double> c_gradient_limit(const std::vector<int> &dims, const double 
       int ipos, jpos, kpos;
       ind2sub(inod, dims[0], dims[1], &ipos, &jpos, &kpos);
 
-      // ---- gather indices using 4 (6 in 3d) edge stencil centered on inod
+      // ---- gather indices centered on inod
       npos[0] = inod;
-
+      // right
       npos[1] =
           sub2ind(ipos, std::min(jpos + 1, dims[1]), kpos, dims[0], dims[1]);
-
+      // left
       npos[2] = sub2ind(ipos, std::max(jpos - 1, 1), kpos, dims[0], dims[1]);
-
-      npos[3] =
-          sub2ind(std::min(ipos + 1, dims[0]), jpos, kpos, dims[0], dims[1]);
-
+      // top
+      npos[3] = sub2ind(std::min(ipos + 1, dims[0]), jpos, kpos, dims[0], dims[1]);
+      // bottom
       npos[4] = sub2ind(std::max(ipos - 1, 1), jpos, kpos, dims[0], dims[1]);
 
-      npos[5] =
-          sub2ind(ipos, jpos, std::min(kpos + 1, dims[2]), dims[0], dims[1]);
+      // top right diagonal
+      npos[5] = sub2ind(std::min(ipos +1, dims[0]), std::min(jpos +1, dims[1]), kpos, dims[0], dims[1]);
+      // top left diagonal
+      npos[6] = sub2ind(std::max(ipos -1 , 1), std::min(jpos +1, dims[1]), kpos, dims[0], dims[1]);
+      // bottom left diagonal
+      npos[7] = sub2ind(std::max(ipos -1 , 1), std::max(jpos -1, 1), kpos, dims[0], dims[1]);
+      // bottom right diagonal
+      npos[8] = sub2ind(std::min(ipos +1 , dims[0]), std::min(jpos+1, dims[1]), kpos, dims[0], dims[1]);
 
-      npos[6] = sub2ind(ipos, jpos, std::max(kpos - 1, 1), dims[0], dims[1]);
-
-      for (std::size_t u = 0; u < 7; u++)
+      for (std::size_t u = 0; u < 9; u++)
         npos[u]--;
 
       int nod1 = npos[0];
       assert(nod1 < ffun_s.size());
       assert(nod1 > -1);
 
-      for (std::size_t p = 2; p < 7; p++) {
+      for (std::size_t p = 2; p < 9; p++) {
 
         int nod2 = npos[p];
         assert(nod2 < ffun_s.size());

--- a/oceanmesh/cpp/HamiltonJacobi.cpp
+++ b/oceanmesh/cpp/HamiltonJacobi.cpp
@@ -139,12 +139,13 @@ std::vector<double> c_gradient_limit(const std::vector<int> &dims,
         assert(nod2 < ffun_s.size());
         assert(nod2 > -1);
 
+        // use non-diagonal element length for p = [1..4]
         double elenp = elen;
 
+        // use diagonal element length for p = [5..8]
         if (p > 4) {
           elenp = elend;
         }
-
 
         //----------------- calc. limits about min.-value
         if (ffun_s[nod1] > ffun_s[nod2]) {

--- a/oceanmesh/cpp/HamiltonJacobi.cpp
+++ b/oceanmesh/cpp/HamiltonJacobi.cpp
@@ -60,7 +60,7 @@ std::vector<int> findIndices(const std::vector<int> &A, const int value) {
 }
 
 // solve the Hamilton-Jacobi equation
-std::vector<double> c_gradient_limit(const std::vector<int> &dims, 
+std::vector<double> c_gradient_limit(const std::vector<int> &dims,
                               const double &elen,
                               const double &dfdx, const int &imax,
                               const std::vector<double> &ffun) {
@@ -80,7 +80,7 @@ std::vector<double> c_gradient_limit(const std::vector<int> &dims,
   std::vector<double> ffun_s;
   ffun_s.resize(ffun.size());
   ffun_s = ffun;
-  
+
 
   int maxSz = dims[0] * dims[1] * dims[2];
 
@@ -139,13 +139,10 @@ std::vector<double> c_gradient_limit(const std::vector<int> &dims,
         assert(nod2 < ffun_s.size());
         assert(nod2 > -1);
 
-        if (p < 5) {
-        
-          double elenp = elen;
+        double elenp = elen;
 
-        } else {
-        
-          double elenp = elend;
+        if (p > 4) {
+          elenp = elend;
         }
 
 

--- a/oceanmesh/cpp/HamiltonJacobi.cpp
+++ b/oceanmesh/cpp/HamiltonJacobi.cpp
@@ -1,0 +1,196 @@
+/* solve the Hamilton-Jacobi equation to smooth a raster field
+   Persson, PO. Engineering with Computers (2006) 22: 95.
+   https://doi.org/10.1007/s00366-006-0014-1 kjr, usp, 2019
+*/
+#include <pybind11/complex.h>
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <algorithm>
+#include <array>
+#include <assert.h>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <math.h>
+#include <stdio.h>
+#include <vector>
+
+#include <chrono>
+
+#define EPS 1e-9
+
+namespace py = pybind11;
+
+// for column major order with 1-based indexing
+int sub2ind(const int row, const int col, const int zpos, const int nrows,
+            const int ncols) {
+  return (col - 1) * nrows + row +
+         (zpos - 1) * (nrows * ncols); // trailing -1 is for zero-based indexing
+}
+
+//
+void ind2sub(const int index, const int nrows, const int ncols, int *i, int *j,
+             int *k) {
+  int tmp2;
+  double tmp = (double)index;
+  double a = nrows * ncols;
+  *k = std::ceil(tmp / a);
+  tmp2 = (int)tmp - (*k - 1) * nrows * ncols;
+  *j = 1 + std::floor((tmp2 - 1) / nrows);
+  *i = tmp2 - (*j - 1) * nrows;
+  assert(*i > 0);
+  assert(*j > 0);
+  assert(*k > 0);
+}
+
+//
+bool IsNegative(int i) { return (i < 0); }
+
+// find indices in linear time where A==value
+std::vector<int> findIndices(const std::vector<int> &A, const int value) {
+  std::vector<int> B;
+  for (std::size_t i = 0; i < A.size(); i++) {
+    if (A[i] == value) {
+      B.push_back(i);
+    }
+  }
+  return B;
+}
+
+// solve the Hamilton-Jacobi equation
+std::vector<double> c_gradient_limit(const std::vector<int> &dims, const double &elen,
+                              const double &dfdx, const int &imax,
+                              const std::vector<double> &ffun) {
+
+  assert(dims[0] > 0 && dims[1] > 0 && dims[2] > 0);
+
+  std::vector<int> aset(dims[0] * dims[1] * dims[2], -1);
+
+  double ftol = *(std::min_element(ffun.begin(), ffun.end())) * std::sqrt(EPS);
+
+  std::array<int, 7> npos;
+  npos.fill(0);
+
+  // allocate output
+  std::vector<double> ffun_s;
+  ffun_s.resize(ffun.size());
+  ffun_s = ffun;
+
+  int maxSz = dims[0] * dims[1] * dims[2];
+
+  for (int iter = 0; iter < imax; iter++) {
+
+    //------------------------- find "active" nodes this pass
+    auto aidx = findIndices(aset, iter - 1);
+
+    //------------------------- convergence
+    if (aidx.empty()) {
+      // std::cout << "INFO: Converged in " << iter << " iterations." <<
+      // std::endl;
+      break;
+    }
+
+    for (std::size_t i = 0; i < aidx.size(); i++) {
+
+      //----- map triply indexed to singly indexed
+      int inod = aidx[i] + 1; // add one to match 1-based indexing
+
+      //----- calculate the i,j,k position
+      int ipos, jpos, kpos;
+      ind2sub(inod, dims[0], dims[1], &ipos, &jpos, &kpos);
+
+      // ---- gather indices using 4 (6 in 3d) edge stencil centered on inod
+      npos[0] = inod;
+
+      npos[1] =
+          sub2ind(ipos, std::min(jpos + 1, dims[1]), kpos, dims[0], dims[1]);
+
+      npos[2] = sub2ind(ipos, std::max(jpos - 1, 1), kpos, dims[0], dims[1]);
+
+      npos[3] =
+          sub2ind(std::min(ipos + 1, dims[0]), jpos, kpos, dims[0], dims[1]);
+
+      npos[4] = sub2ind(std::max(ipos - 1, 1), jpos, kpos, dims[0], dims[1]);
+
+      npos[5] =
+          sub2ind(ipos, jpos, std::min(kpos + 1, dims[2]), dims[0], dims[1]);
+
+      npos[6] = sub2ind(ipos, jpos, std::max(kpos - 1, 1), dims[0], dims[1]);
+
+      for (std::size_t u = 0; u < 7; u++)
+        npos[u]--;
+
+      int nod1 = npos[0];
+      assert(nod1 < ffun_s.size());
+      assert(nod1 > -1);
+
+      for (std::size_t p = 2; p < 7; p++) {
+
+        int nod2 = npos[p];
+        assert(nod2 < ffun_s.size());
+        assert(nod2 > -1);
+
+        //----------------- calc. limits about min.-value
+        if (ffun_s[nod1] > ffun_s[nod2]) {
+
+          double fun1 = ffun_s[nod2] + elen * dfdx;
+          if (ffun_s[nod1] > fun1 + ftol) {
+            ffun_s[nod1] = fun1;
+            aset[nod1] = iter;
+          }
+
+        } else {
+
+          double fun2 = ffun_s[nod1] + elen * dfdx;
+          if (ffun_s[nod2] > fun2 + ftol) {
+            ffun_s[nod2] = fun2;
+            aset[nod2] = iter;
+          }
+        }
+      }
+    }
+    // std::cout << "ITER: " << iter << std::endl;
+  }
+  return ffun_s;
+}
+
+// Python wrapper
+py::array
+gradient_limit(py::array_t<int, py::array::c_style | py::array::forcecast> dims,
+        const double elen, const double dfdx, const int imax,
+        py::array_t<double, py::array::c_style | py::array::forcecast> ffun) {
+  int num_points = ffun.size();
+
+  std::vector<double> cffun(num_points);
+  std::vector<int> cdims(3);
+
+  std::memcpy(cffun.data(), ffun.data(), num_points * sizeof(double));
+  std::memcpy(cdims.data(), dims.data(), 3 * sizeof(int));
+
+  std::vector<double> sffun = c_gradient_limit(cdims, elen, dfdx, imax, cffun);
+
+  ssize_t sodble = sizeof(double);
+  std::vector<ssize_t> shape = {num_points, 1};
+  std::vector<ssize_t> strides = {sodble, sodble};
+
+  // return 2-D NumPy array
+  return py::array(
+      py::buffer_info(sffun.data(),   /* data as contiguous array  */
+                      sizeof(double), /* size of one scalar        */
+                      py::format_descriptor<double>::format(), /* data type */
+                      2,      /* number of dimensions      */
+                      shape,  /* shape of the matrix       */
+                      strides /* strides for each axis     */
+                      ));
+}
+
+PYBIND11_MODULE(HamiltonJacobi, m) {
+
+  m.doc() = "pybind11 module for gradient limiting a scalar field";
+
+  m.def("gradient_limit", &gradient_limit,
+        "The function which gradient limits a scalar field reshaped to a "
+        "vector.");
+}

--- a/oceanmesh/cpp/HamiltonJacobi.cpp
+++ b/oceanmesh/cpp/HamiltonJacobi.cpp
@@ -60,7 +60,8 @@ std::vector<int> findIndices(const std::vector<int> &A, const int value) {
 }
 
 // solve the Hamilton-Jacobi equation
-std::vector<double> c_gradient_limit(const std::vector<int> &dims, const double &elen,
+std::vector<double> c_gradient_limit(const std::vector<int> &dims, 
+                              const double &elen,
                               const double &dfdx, const int &imax,
                               const std::vector<double> &ffun) {
 
@@ -73,10 +74,13 @@ std::vector<double> c_gradient_limit(const std::vector<int> &dims, const double 
   std::array<int, 9> npos;
   npos.fill(0);
 
+  double elend = elen * std::sqrt(2.0);
+
   // allocate output
   std::vector<double> ffun_s;
   ffun_s.resize(ffun.size());
   ffun_s = ffun;
+  
 
   int maxSz = dims[0] * dims[1] * dims[2];
 
@@ -129,16 +133,26 @@ std::vector<double> c_gradient_limit(const std::vector<int> &dims, const double 
       assert(nod1 < ffun_s.size());
       assert(nod1 > -1);
 
-      for (std::size_t p = 2; p < 9; p++) {
+      for (std::size_t p = 1; p < 9; p++) {
 
         int nod2 = npos[p];
         assert(nod2 < ffun_s.size());
         assert(nod2 > -1);
 
+        if (p < 5) {
+        
+          double elenp = elen;
+
+        } else {
+        
+          double elenp = elend;
+        }
+
+
         //----------------- calc. limits about min.-value
         if (ffun_s[nod1] > ffun_s[nod2]) {
 
-          double fun1 = ffun_s[nod2] + elen * dfdx;
+          double fun1 = ffun_s[nod2] + elenp * dfdx;
           if (ffun_s[nod1] > fun1 + ftol) {
             ffun_s[nod1] = fun1;
             aset[nod1] = iter;
@@ -146,7 +160,7 @@ std::vector<double> c_gradient_limit(const std::vector<int> &dims, const double 
 
         } else {
 
-          double fun2 = ffun_s[nod1] + elen * dfdx;
+          double fun2 = ffun_s[nod1] + elenp * dfdx;
           if (ffun_s[nod2] > fun2 + ftol) {
             ffun_s[nod2] = fun2;
             aset[nod2] = iter;

--- a/oceanmesh/edgefx.py
+++ b/oceanmesh/edgefx.py
@@ -39,7 +39,7 @@ def enforce_mesh_gradation(grid, gradation=0.15, verbose=1):
     cell_size = cell_size.flatten("F")
     tmp = gradient_limit([*sz], elen, gradation, 10000, cell_size)
     tmp = numpy.reshape(tmp, (sz[0], sz[1]), "F")
-    grid_limited = Grid(bbox=grid.bbox, dx=grid.dx, values=tmp)
+    grid_limited = Grid(bbox=grid.bbox, dx=grid.dx, values=tmp, hmin=grid.hmin)
     grid_limited.build_interpolant()
     return grid_limited
 

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ class CMakeBuild(build_ext):
 
 setup(
     ext_modules=[
+        CMakeExtension("oceanmesh/cpp/HamiltonJacobi"),
         CMakeExtension("oceanmesh/cpp/delaunay_class"),
         CMakeExtension("oceanmesh/cpp/fast_geometry"),
     ],

--- a/tests/test_grade.py
+++ b/tests/test_grade.py
@@ -17,7 +17,7 @@ def test_grade():
 
     domain = om.signed_distance_function(shore)
 
-    points, cells = om.generate_mesh(domain, test_edge_length)
+    points, cells = om.generate_mesh(domain, test_edge_length, max_iter=100)
 
     points, cells = om.make_mesh_boundaries_traversable(points, cells)
 

--- a/tests/test_grade.py
+++ b/tests/test_grade.py
@@ -1,0 +1,12 @@
+ --import oceanmesh as om
+
+   fname = "gshhg-shp-2.3.7/GSHHS_shp/f/GSHHS_f_L1.shp"
+
+   bbox, min_edge_length = (-75.000, -70.001, 40.0001, 41.9000), 1e3
+
+   shore = om.Shoreline(fname, bbox, min_edge_length)
+
+   edge_length = om.distance_sizing_function(shore, rate=0.35)
+
+   test_edge_length = om.enforce_mesh_gradation(edge_length, gradation=0.20)
+   test_edge_length.plot(show=False, file_name="test_edge_length.png")

--- a/tests/test_grade.py
+++ b/tests/test_grade.py
@@ -1,3 +1,5 @@
+import matplotlib.pyplot as plt
+import matplotlib.tri as tri
 import oceanmesh as om
 
 
@@ -12,3 +14,18 @@ def test_grade():
 
     test_edge_length = om.enforce_mesh_gradation(edge_length, gradation=0.20)
     test_edge_length.plot(show=False, file_name="test_edge_length.png")
+
+    domain = om.signed_distance_function(shore)
+
+    points, cells = om.generate_mesh(domain, test_edge_length)
+
+    points, cells = om.make_mesh_boundaries_traversable(points, cells)
+
+    points, cells = om.delete_faces_connected_to_one_face(points, cells)
+
+    # plot
+    fig, ax = plt.subplots()
+    ax.set_aspect("equal")
+    triang = tri.Triangulation(points[:, 0], points[:, 1], cells)
+    ax.triplot(triang, "-", lw=1)
+    plt.show()

--- a/tests/test_grade.py
+++ b/tests/test_grade.py
@@ -11,4 +11,4 @@ def test_grade():
     edge_length = om.distance_sizing_function(shore, rate=0.35)
 
     test_edge_length = om.enforce_mesh_gradation(edge_length, gradation=0.20)
-    test_edge_length.plot(show=False, file_name="test_edge_length.png")
+    test_edge_length.plot(show=False, file_name="test_grade_edgelength.png")

--- a/tests/test_grade.py
+++ b/tests/test_grade.py
@@ -1,12 +1,14 @@
- --import oceanmesh as om
+import oceanmesh as om
 
-   fname = "gshhg-shp-2.3.7/GSHHS_shp/f/GSHHS_f_L1.shp"
 
-   bbox, min_edge_length = (-75.000, -70.001, 40.0001, 41.9000), 1e3
+def test_grade():
+    fname = "gshhg-shp-2.3.7/GSHHS_shp/f/GSHHS_f_L1.shp"
 
-   shore = om.Shoreline(fname, bbox, min_edge_length)
+    bbox, min_edge_length = (-75.000, -70.001, 40.0001, 41.9000), 1e3
 
-   edge_length = om.distance_sizing_function(shore, rate=0.35)
+    shore = om.Shoreline(fname, bbox, min_edge_length)
 
-   test_edge_length = om.enforce_mesh_gradation(edge_length, gradation=0.20)
-   test_edge_length.plot(show=False, file_name="test_edge_length.png")
+    edge_length = om.distance_sizing_function(shore, rate=0.35)
+
+    test_edge_length = om.enforce_mesh_gradation(edge_length, gradation=0.20)
+    test_edge_length.plot(show=False, file_name="test_edge_length.png")


### PR DESCRIPTION
* enables one to gradient limit a mesh size function 
```
 import oceanmesh as om
 import numpy as np
 
 fname = "GSHHS_shp/f/GSHHS_f_L1.shp"
 bbox, min_edge_length = (-75, -65.0, 45.0, 50.00), 1e3
 shore = om.Shoreline(fname, bbox, min_edge_length)
 distance_edge_length = om.distance_sizing_function(
     shore, max_edge_length=50e3, rate=0.35
 )
 distance_edge_length.plot(show=False, file_name="d15.png")
 d = om.enforce_mesh_gradation(distance_edge_length, gradation=0.05)
 d.plot(show=False, file_name="d05.png")
 ```