### PR TITLE
simplify multiscale meshing

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,44 +429,26 @@ points, cells = om.laplacian2(points, cells)
 
 # plot it showing the different levels of resolution
 triang = tri.Triangulation(points[:, 0], points[:, 1], cells)
-gs = gridspec.GridSpec(2, 2)
-gs.update(wspace=0.5)
+gs = gridspec.GridSpec(2, 1)
+gs.update(wspace=0.1)
 plt.figure()
-
-bbox3 = np.array(
-    [
-        [-73.78, 40.60],
-        [-73.75, 40.60],
-        [-73.75, 40.64],
-        [-73.78, 40.64],
-        [-73.78, 40.60],
-    ],
-    dtype=float,
-)
 
 ax = plt.subplot(gs[0, 0])  #
 ax.set_aspect("equal")
-ax.triplot(triang, "-", lw=1)
+ax.triplot(triang, "-", lw=0.5)
 ax.plot(bbox2[:, 0], bbox2[:, 1], "r--")
-ax.plot(bbox3[:, 0], bbox3[:, 1], "m--")
 
-ax = plt.subplot(gs[0, 1])
+ax = plt.subplot(gs[1, 0])  #
+buf = 0.07
+ax.set_xlim([min(bbox2[:,0])-buf,max(bbox2[:,0])+buf])
+ax.set_ylim([min(bbox2[:,1])-buf,max(bbox2[:,1])+buf])
 ax.set_aspect("equal")
-ax.triplot(triang, "-", lw=1)
+ax.triplot(triang, "-", lw=0.5)
 ax.plot(bbox2[:, 0], bbox2[:, 1], "r--")
-ax.set_xlim(np.amin(bbox2[:, 0]), np.amax(bbox2[:, 0]))
-ax.set_ylim(np.amin(bbox2[:, 1]), np.amax(bbox2[:, 1]))
-ax.plot(bbox3[:, 0], bbox3[:, 1], "m--")
 
-ax = plt.subplot(gs[1, :])
-ax.set_aspect("equal")
-ax.triplot(triang, "-", lw=1)
-ax.set_xlim(-73.78, -73.75)
-ax.set_ylim(40.60, 40.64)
 plt.show()
 ```
-![Multiscale](https://user-images.githubusercontent.com/18619644/136119785-8746552d-4ff6-44c3-9aa1-3e4981ba3518.png)
-
+![Multiscale](<img width="747" alt="image" src="https://user-images.githubusercontent.com/21131934/136140049-9eee309a-987f-4128-9fe2-bb207f972be3.png">
 
 See the tests inside the `testing/` folder for more inspiration. Work is ongoing on this package.
 

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ ax.plot(bbox2[:, 0], bbox2[:, 1], "r--")
 
 plt.show()
 ```
-![Multiscale](<img width="747" alt="image" src="https://user-images.githubusercontent.com/21131934/136140049-9eee309a-987f-4128-9fe2-bb207f972be3.png">
+<img width="747" alt="image" src="https://user-images.githubusercontent.com/21131934/136140049-9eee309a-987f-4128-9fe2-bb207f972be3.png">
 
 See the tests inside the `testing/` folder for more inspiration. Work is ongoing on this package.
 

--- a/README.md
+++ b/README.md
@@ -391,15 +391,23 @@ EPSG = 4326  # EPSG:4326 or WGS84
 extent1 = om.Region(extent=(-75.00, -70.001, 40.0001, 41.9000), crs=EPSG)
 min_edge_length1 = 0.01  # minimum mesh size in domain in projection
 
-bbox2, min_edge_length2 = (-74.85, -73.75, 40.4, 41), 50.0
-extent2 = om.Region(extent=(-74.85, -73.75, 40.4, 41.00), crs=EPSG)
+bbox2 = [
+    [-73.9481, 40.6028],
+    [-74.0186, 40.5688],
+    [-73.9366, 40.5362],
+    [-73.7269, 40.5626],
+    [-73.7231, 40.6459],
+    [-73.8242, 40.6758],
+    [-73.9481, 40.6028],
+]
+extent2 = om.Region(extent=bbox2, crs=EPSG)
 min_edge_length2 = 4.6e-4  # minimum mesh size in domain in projection
 
-s1 = om.Shoreline(fname1, extent1.bbox, min_edge_length1)
+s1 = om.Shoreline(fname1, extent1.bbox, min_edge_length1, minimum_area_mult=0.01)
 sdf1 = om.signed_distance_function(s1)
-el1 = om.distance_sizing_function(s1, max_edge_length=5e3)
+el1 = om.distance_sizing_function(s1, max_edge_length=0.05)
 
-s2 = om.Shoreline(fname1, extent2.bbox, min_edge_length2)
+s2 = om.Shoreline(fname1, extent2.bbox, min_edge_length2, minimum_area_mult=0.01)
 sdf2 = om.signed_distance_function(s2)
 el2 = om.distance_sizing_function(s2)
 
@@ -408,9 +416,6 @@ el2 = om.distance_sizing_function(s2)
 points, cells = om.generate_multiscale_mesh(
     [sdf1, sdf2],
     [el1, el2],
-    blend_width=5e3,  # width of blend zone around nest
-    blend_polynomial=3,  # inverse distance weighting (IWD) polynomial
-    blend_nnear=16,  # number of points to consider in IDW
 )
 
 # remove degenerate mesh faces and other common problems in the mesh

--- a/README.md
+++ b/README.md
@@ -403,11 +403,11 @@ bbox2 = [
 extent2 = om.Region(extent=bbox2, crs=EPSG)
 min_edge_length2 = 4.6e-4  # minimum mesh size in domain in projection
 
-s1 = om.Shoreline(fname1, extent1.bbox, min_edge_length1, minimum_area_mult=0.01)
+s1 = om.Shoreline(fname1, extent1.bbox, min_edge_length1)
 sdf1 = om.signed_distance_function(s1)
 el1 = om.distance_sizing_function(s1, max_edge_length=0.05)
 
-s2 = om.Shoreline(fname1, extent2.bbox, min_edge_length2, minimum_area_mult=0.01)
+s2 = om.Shoreline(fname1, extent2.bbox, min_edge_length2)
 sdf2 = om.signed_distance_function(s2)
 el2 = om.distance_sizing_function(s2)
 

--- a/oceanmesh/mesh_generator.py
+++ b/oceanmesh/mesh_generator.py
@@ -8,10 +8,12 @@ import scipy.sparse as spsparse
 from _delaunay_class import DelaunayTriangulation as DT
 from _fast_geometry import unique_edges
 
+from .clean import _external_topology
 from .edgefx import multiscale_sizing_function
 from .fix_mesh import fix_mesh
 from .grid import Grid
-from .signed_distance_function import Domain, multiscale_signed_distance_function
+from .signed_distance_function import (Domain,
+                                       multiscale_signed_distance_function)
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +48,7 @@ def _parse_kwargs(kwargs):
             "blend_polynomial",
             "blend_max_iter",
             "blend_nnear",
+            "lock_boundary",
         }:
             pass
         else:
@@ -97,10 +100,11 @@ def generate_multiscale_mesh(domains, edge_lengths, **kwargs):
         "points": None,
         "min_edge_length": None,
         "plot": 999999,
-        "blend_width": 5000,
+        "blend_width": 2500,
         "blend_polynomial": 2,
         "blend_max_iter": 20,
         "blend_nnear": 256,
+        "lock_boundary": False,
     }
     opts.update(kwargs)
     _parse_kwargs(kwargs)
@@ -132,6 +136,7 @@ def generate_multiscale_mesh(domains, edge_lengths, **kwargs):
         min_edge_length=global_minimum,
         points=_p,
         max_iter=opts["blend_max_iter"],
+        lock_boundary=True,
         **kwargs,
     )
 
@@ -181,6 +186,7 @@ def generate_mesh(domain, edge_length, **kwargs):
         "points": None,
         "min_edge_length": None,
         "plot": 999999,
+        "lock_boundary": False,
     }
     opts.update(kwargs)
     _parse_kwargs(kwargs)
@@ -204,6 +210,7 @@ def generate_mesh(domain, edge_length, **kwargs):
     deps = np.sqrt(np.finfo(np.double).eps)  # * np.amin(min_edge_length)
 
     pfix, nfix = _unpack_pfix(_DIM, opts)
+    lock_boundary = opts["lock_boundary"]
 
     if opts["points"] is None:
         p = _generate_initial_points(
@@ -235,8 +242,13 @@ def generate_mesh(domain, edge_length, **kwargs):
         # Get the current topology of the triangulation
         p, t = _get_topology(dt)
 
-        # Find where pfix went
         ifix = []
+        if lock_boundary:
+            _, bpts = _external_topology(p, t)
+            for fix in bpts:
+                ifix.append(_closest_node(fix, p))
+
+        # Find where pfix went
         if nfix > 0:
             for fix in pfix:
                 ifix.append(_closest_node(fix, p))
@@ -246,7 +258,7 @@ def generate_mesh(domain, edge_length, **kwargs):
 
         # plot the mesh every count iterations
         if count % opts["plot"] == 0 and count != 0:
-            plot_mesh(p, t, count=count, pause=0.2)
+            plot_mesh(p, t, count=count, pause=5.0)
 
         # Number of iterations reached, stop.
         if count == (max_iter - 1):
@@ -436,11 +448,7 @@ def _unpack_pfix(dim, opts):
     if opts["pfix"] is not None:
         pfix = np.array(opts["pfix"], dtype="d")
         nfix = len(pfix)
-        if opts["verbose"]:
-            print(
-                "Constraining " + str(nfix) + " fixed points..",
-                flush=True,
-            )
+        logger.info(f"Constraining {nfix} fixed points..")
     return pfix, nfix
 
 


### PR DESCRIPTION
* `Union` of signed distance functions to define multiscale domain (no need for this `UnionWithCovers` concept). 
* Previous issue was associated with islands smaller than the minimum area threshold being removed in the main domain but not in the nests (or vice versa). 
